### PR TITLE
Fix CubeMapArray size from texture height

### DIFF
--- a/Runtime/CBIRPManagerEditor.cs
+++ b/Runtime/CBIRPManagerEditor.cs
@@ -1,4 +1,4 @@
-#if !COMPILER_UDONSHARP && UNITY_EDITOR
+﻿#if !COMPILER_UDONSHARP && UNITY_EDITOR
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -150,12 +150,9 @@ namespace CBIRP
                 var reflectionProbe = probeInstances[i].probe;
                 Texture probe = reflectionProbe.texture;
 
-                for (int mip = 0; mip < referenceProbe.mipmapCount; mip++)
+                for (int side = 0; side < 6; side++)
                 {
-                    for (int side = 0; side < 6; side++)
-                    {
-                        Graphics.CopyTexture(probe, side, mip, array, (i * 6) + side, mip);
-                    }
+                    Graphics.CopyTexture(probe, side, array, (i * 6) + side);
                 }
 
                 var cbirpProbe = reflectionProbe.transform.GetComponent<CBIRPReflectionProbe>();

--- a/Runtime/CBIRPManagerEditor.cs
+++ b/Runtime/CBIRPManagerEditor.cs
@@ -1,4 +1,4 @@
-﻿#if !COMPILER_UDONSHARP && UNITY_EDITOR
+#if !COMPILER_UDONSHARP && UNITY_EDITOR
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -143,7 +143,7 @@ namespace CBIRP
             }
 
             var referenceProbe = probeInstances[0].probe.texture as Cubemap;
-            var array = new CubemapArray(referenceProbe.width, referenceProbe.height, referenceProbe.format, true);
+            var array = new CubemapArray(referenceProbe.width, probeInstances.Length, referenceProbe.format, true);
 
             for (int i = 0; i < probeInstances.Length; i++)
             {


### PR DESCRIPTION
Easy fix, the texture height was taken as number of cubemaps in the array ^^

I suspected it was something with the mipmaps but wasn't. Still don't need to copy them separately in this case, maybe making it a bit faster(see commit message).